### PR TITLE
Increase performance of libelf section list

### DIFF
--- a/libelf/elf_end.c
+++ b/libelf/elf_end.c
@@ -40,7 +40,8 @@ int
 elf_end(Elf *e)
 {
 	Elf *sv;
-	Elf_Scn *scn, *tscn;
+	Elf_Scn *scn;
+	size_t i;
 
 	if (e == NULL || e->e_activations == 0)
 		return (0);
@@ -66,9 +67,12 @@ elf_end(Elf *e)
 			/*
 			 * Reclaim all section descriptors.
 			 */
-			STAILQ_FOREACH_SAFE(scn, &e->e_u.e_elf.e_scn, s_next,
-			    tscn)
- 				scn = _libelf_release_scn(scn);
+			LIBELF_SCNLIST_FOREACH(e, scn, i) {
+				if (scn != NULL) {
+					_libelf_release_scn(scn);
+					e->e_u.e_elf.e_nscn--;
+				}
+			}
 			break;
 		case ELF_K_NUM:
 			assert(0);

--- a/libelf/elf_scn.c
+++ b/libelf/elf_scn.c
@@ -95,10 +95,7 @@ _libelf_load_section_headers(Elf *e, void *ehdr)
 	 */
 
 	i = 0;
-	if (!STAILQ_EMPTY(&e->e_u.e_elf.e_scn)) {
-		assert(STAILQ_FIRST(&e->e_u.e_elf.e_scn) ==
-		    STAILQ_LAST(&e->e_u.e_elf.e_scn, _Elf_Scn, s_next));
-
+	if (!LIBELF_SCNLIST_EMPTY(e)) {
 		i = 1;
 		src += fsz;
 	}
@@ -148,9 +145,9 @@ elf_getscn(Elf *e, size_t index)
 	    _libelf_load_section_headers(e, ehdr) == 0)
 		return (NULL);
 
-	STAILQ_FOREACH(s, &e->e_u.e_elf.e_scn, s_next)
-		if (s->s_ndx == index)
-			return (s);
+	s = LIBELF_SCNLIST_ENTRY(e, index);
+	if (s != NULL && s->s_ndx == index)
+		return (s);
 
 	LIBELF_SET_ERROR(ARGUMENT, 0);
 	return (NULL);
@@ -201,7 +198,7 @@ elf_newscn(Elf *e)
 	    _libelf_load_section_headers(e, ehdr) == 0)
 		return (NULL);
 
-	if (STAILQ_EMPTY(&e->e_u.e_elf.e_scn)) {
+	if (LIBELF_SCNLIST_EMPTY(e)) {
 		assert(e->e_u.e_elf.e_nscn == 0);
 		if ((scn = _libelf_allocate_scn(e, (size_t) SHN_UNDEF)) ==
 		    NULL)
@@ -231,5 +228,5 @@ elf_nextscn(Elf *e, Elf_Scn *s)
 	}
 
 	return (s == NULL ? elf_getscn(e, (size_t) 1) :
-	    STAILQ_NEXT(s, s_next));
+	    LIBELF_SCNLIST_NEXT(e, s));
 }

--- a/libelf/libelf_ehdr.c
+++ b/libelf/libelf_ehdr.c
@@ -47,7 +47,7 @@ _libelf_load_extended(Elf *e, int ec, uint64_t shoff, uint16_t phnum,
 	    size_t _c, int _swap);
 	uint32_t shtype;
 
-	assert(STAILQ_EMPTY(&e->e_u.e_elf.e_scn));
+	assert(LIBELF_SCNLIST_EMPTY(e));
 
 	fsz = _libelf_fsize(ELF_T_SHDR, ec, e->e_version, 1);
 	assert(fsz > 0);

--- a/libelf/libelf_extended.c
+++ b/libelf/libelf_extended.c
@@ -39,7 +39,7 @@ _libelf_getscn0(Elf *e)
 {
 	Elf_Scn *s;
 
-	if ((s = STAILQ_FIRST(&e->e_u.e_elf.e_scn)) != NULL)
+	if ((s = LIBELF_SCNLIST_ENTRY(e, 0)) != NULL)
 		return (s);
 
 	return (_libelf_allocate_scn(e, (size_t) SHN_UNDEF));


### PR DESCRIPTION
The existing internal section list is implemented as a singly-linked
tail queue, and exhibits poor (O(n)) performance for some library
functions (e.g. elf_getscn(), elf_strptr()).

By replacing the queue with a resizable array, we can obtain O(1) access
time and O(1) insertion time, since each section already keeps track of
its own index.